### PR TITLE
Add glob pattern for Temporal-related 402 tests

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
   "cSpell.words": [
+    "emporal",
     "NOINPUT",
     "runtest"
   ]

--- a/index.mjs
+++ b/index.mjs
@@ -40,9 +40,9 @@ import yaml from 'js-yaml';
  *   the global namespace, as well as Temporal-related changes polyfilled into
  *   `Intl` and `Date` built-in objects.
  * @property {string} test262Dir Root directory of the test262 submodule repo.
- * @property {string[]=} testGlobs If omitted, all tests will be run. This
- *   option provides glob patterns that specify a subset of tests to be run.
- *   Globs are resolved relative to `test/**∕Temporal/` subdirectories of
+ * @property {string[]=} testGlobs If omitted, all Temporal tests will be run.
+ *   This option provides glob patterns that specify a subset of tests to be
+ *   run. Globs are resolved relative to `test/**∕Temporal/` subdirectories of
  *   `test262Dir`. If a pattern doesn't match any files relative to
  *   `test/**∕Temporal/`, it will also try to match relative to the current
  *   working directory, so that tab completion works. Example:
@@ -64,9 +64,9 @@ import yaml from 'js-yaml';
  *     the global namespace, as well as Temporal-related changes polyfilled into
  *     `Intl` and `Date` built-in objects.
  *   - `test262Dir: string` - Root directory of the test262 submodule repo
- *   - `testGlobs?: string[]` - If omitted, all tests will be run. This option
- *     provides glob patterns that specify a subset of tests to be run. Globs
- *     are resolved relative to `test/**∕Temporal/` subdirectories of
+ *   - `testGlobs?: string[]` - If omitted, all Temporal tests will be run. This
+ *     option provides glob patterns that specify a subset of tests to be run.
+ *     Globs are resolved relative to `test/**∕Temporal/` subdirectories of
  *     `test262Dir`. If a pattern doesn't match any files relative to
  *     `test/**∕Temporal/`, it will also try to match relative to the current
  *     working directory, so that tab completion works. Example:
@@ -166,8 +166,10 @@ export default function runTest262({ test262Dir, testGlobs, polyfillCodeFile, ex
   if (testGlobs.length === 0) {
     [
       path.resolve(testSubdirectory, '**/Temporal/**/*.js'),
+      // e.g. intl402/DateTimeFormat/prototype/format/temporal-objects-resolved-time-zone.js
+      path.resolve(testSubdirectory, 'intl402/**/*[tT]emporal*.js'),
       // "p*" is a workaround because there is no toTemporalInstant dir at this time
-      path.resolve(testSubdirectory, 'built-ins/Date/p*/toTemporalInstant/*.js')
+      path.resolve(testSubdirectory, 'built-ins/Date/p*/toTemporalInstant/*.js')      
     ].forEach((defaultGlob) => globResults.push(...globSync(defaultGlob, GLOB_OPTS)));
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@js-temporal/temporal-test262-runner",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@js-temporal/temporal-test262-runner",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "ansi-colors": "^4.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@js-temporal/temporal-test262-runner",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Lightweight runner for ECMAScript Temporal's Test262 tests",
   "main": "index.mjs",
   "scripts": {


### PR DESCRIPTION
Apparently there are a few more Temporal-related tests in the 402 section of Test262 that weren't captured by the original set of globs because the "temporal" was in the filename, not the directory name. 

This commit adds a glob pattern to catch "temporal" in the filename too.