### PR TITLE
Add time-zone-related DateTimeFormat test globs

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -212,6 +212,9 @@ export default function runTest262({ test262Dir, testGlobs, polyfillCodeFile, ex
       path.resolve(testSubdirectory, '**/Temporal/**/*.js'),
       // e.g. intl402/DateTimeFormat/prototype/format/temporal-objects-resolved-time-zone.js
       path.resolve(testSubdirectory, 'intl402/**/*[tT]emporal*.js'),
+      // Intl tests related to time zones
+      // e.g. intl402/DateTimeFormat/timezone-case-insensitive.js
+      path.resolve(testSubdirectory, 'intl402/DateTimeFormat/**/*[zZ]one*.js'),
       // "p*" is a workaround because there is no toTemporalInstant dir at this time
       path.resolve(testSubdirectory, 'built-ins/Date/p*/toTemporalInstant/*.js')
     ].forEach((defaultGlob) => globResults.push(...globSync(defaultGlob, GLOB_OPTS)));


### PR DESCRIPTION
This PR adds a handful of tests in Intl402 that are related to time zones and which Temporal's changes may affect. There's currently only ~4 tests that are now included, but more will likely be added in the future.