### PR TITLE
Run all DateTimeFormat tests by default

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -228,11 +228,8 @@ export default function runTest262({
   if (testGlobs.length === 0) {
     [
       path.resolve(testSubdirectory, '**/Temporal/**/*.js'),
-      // e.g. intl402/DateTimeFormat/prototype/format/temporal-objects-resolved-time-zone.js
-      path.resolve(testSubdirectory, 'intl402/**/*[tT]emporal*.js'),
-      // Intl tests related to time zones
-      // e.g. intl402/DateTimeFormat/timezone-case-insensitive.js
-      path.resolve(testSubdirectory, 'intl402/DateTimeFormat/**/*[zZ]one*.js'),
+      path.resolve(testSubdirectory, 'intl402/DateTimeFormat/**/*.js'),
+      path.resolve(testSubdirectory, 'intl402/Intl/DateTimeFormat/**/*.js'),
       // "p*" is a workaround because there is no toTemporalInstant dir at this time
       path.resolve(testSubdirectory, 'built-ins/Date/p*/toTemporalInstant/*.js')
     ].forEach((defaultGlob) => globResults.push(...globSync(defaultGlob, GLOB_OPTS)));


### PR DESCRIPTION
These were previously omitted because the tc39/proposal-temporal reference code didn't provide a spec-compliant DateTimeFormat object. Now (most of) those compliance issues have been fixed, let's run those tests.